### PR TITLE
optional key rotation policy, fixed #21

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource null_resource print_values {
 
 resource ibm_kms_key root_key {
   depends_on = [null_resource.print_values]
-  count = var.provision && var.provision_key_rotation_policy ? 1 : 0
+  count = var.provision ? 1 : 0
 
   instance_id  = var.kms_id
   key_name     = local.name
@@ -21,7 +21,7 @@ resource ibm_kms_key root_key {
 }
 
 resource ibm_kms_key_policies root_key_policy {
-  count = var.provision ? 1 : 0
+  count = var.provision && var.provision_key_rotation_policy ? 1 : 0
   instance_id = var.kms_id
   key_id = ibm_kms_key.root_key[0].key_id
   rotation {

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource null_resource print_values {
 
 resource ibm_kms_key root_key {
   depends_on = [null_resource.print_values]
-  count = var.provision ? 1 : 0
+  count = var.provision && var.provision_key_rotation_policy ? 1 : 0
 
   instance_id  = var.kms_id
   key_name     = local.name

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,12 @@ variable "provision" {
   default     = false
 }
 
+variable "provision_key_rotation_policy" {
+  type        = bool
+  description = "Flag indicating that the key rotation policy should be provisioned. If false then a rotation policy will not be created."
+  default     = false
+}
+
 variable "kms_id" {
   type        = string
   description = "The id of the kms instance. Required if kms_enabled is true"


### PR DESCRIPTION
Makes key rotation policy optional (false by default).  Fixes #21 